### PR TITLE
Fixed indentation bug

### DIFF
--- a/minid_client/minid.py
+++ b/minid_client/minid.py
@@ -68,7 +68,7 @@ def _main():
     file_exists = os.path.isfile(args.filename)
     if file_exists:
         checksum = mca.compute_checksum(args.filename)
-	checksum_function = "SHA256"
+        checksum_function = "SHA256"
         entities = mca.get_entities(server, checksum, args.test)
     else:
         entities = mca.get_entities(server, args.filename, False)


### PR DESCRIPTION
Found this indentation bug when installing/running minid:

```Traceback (most recent call last):
  File "/usr/local/bin/minid", line 7, in <module>
    from minid_client.minid import main
  File "/usr/local/lib/python3.6/site-packages/minid_client/minid.py", line 71
    checksum_function = "SHA256"
                               ^
TabError: inconsistent use of tabs and spaces in indentation
```