### PR TITLE
Updates to batch_register function and "minid:" prefix handling

### DIFF
--- a/minid_client/minid_client_api.py
+++ b/minid_client/minid_client_api.py
@@ -12,6 +12,9 @@ if sys.version_info > (3,):
 else:
     from ConfigParser import ConfigParser
 
+MINID_PREFIX = "minid:"
+MINID_ARK_ID = "ark:/57799/"
+
 DEFAULT_CONFIG_PATH = os.path.join(os.path.expanduser('~'), '.minid')
 DEFAULT_CONFIG_FILE = os.path.join(DEFAULT_CONFIG_PATH, 'minid-config.cfg')
 
@@ -251,14 +254,14 @@ def update_entity(server, name, entity, email, code, globus_auth_token=None):
 
 
 def ark2minid(identifier):
-    if identifier.startswith("ark:/57799/"):
-        identifier = identifier.replace("ark:/57799/", "minid:")
+    if identifier.startswith(MINID_ARK_ID):
+        identifier = identifier.replace(MINID_ARK_ID, MINID_PREFIX)
     return identifier
 
 
 def minid2ark(identifier):
-    if identifier.startswith("minid:"):
-        identifier = identifier.replace("minid:", "ark:/57799/")
+    if identifier.startswith(MINID_PREFIX):
+        identifier = identifier.replace(MINID_PREFIX, MINID_ARK_ID)
     return identifier
 
 

--- a/minid_client/minid_client_api.py
+++ b/minid_client/minid_client_api.py
@@ -239,7 +239,7 @@ def update_entity(server, name, entity, email, code, globus_auth_token=None):
     if globus_auth_token is not None:
         headers["Authorization"] = "Bearer " + globus_auth_token
 
-    r = requests.put("%s/%s" % (server, name), json=entity, headers=headers)
+    r = requests.put("%s/%s" % (server, minid2ark(name)), json=entity, headers=headers)
 
     if r.status_code in [200, 201]:
         return r.json()


### PR DESCRIPTION
This PR updates `batch_register` to make it include an identifier of a skipped registration in the result output manifest (rather than just skipping it), when one or more identifiers already exist for the same content. If more than one identifier exists for such content, the identifier returned is the most recent, ACTIVE identifier that does contain an "obsoleted_by" attribute.

Also included in this PR is client side handling of the `minid:` prefix. This logic simply translates responses from the server containing identifiers prefixed with `ark:/57799/` to use the prefix `minid:`.  Likewise, any identifiers prefixed with `minid:` by clients via the CLI or API are translated to `ark:/57799/` before being sent to the server.