### PR TITLE
Added check for 400 errors.

### DIFF
--- a/minid_client/minid_client_api.py
+++ b/minid_client/minid_client_api.py
@@ -146,7 +146,7 @@ def register_user(server, email, name, orcid, globus_auth_token=None):
     if orcid:
         user["orcid"] = orcid
     r = requests.post("%s/user" % server, json=user, headers=headers)
-    if r.status_code in [401, 403, 500]:
+    if r.status_code in [400, 401, 403, 500]:
         raise MinidAPIException('Failed to register user', code=r.status_code, **r.json())
     else:
         return r.json()


### PR DESCRIPTION
The minid client api wouldn't throw errors on general 400s from the server. The result is logging can return misleading information that a bad user command has succeeded when it has not. For example, if a user registers without setting a username/email, they may see a message like: 

    2018-06-05 12:46:24,983 - INFO - Registering new user "None" with email "None"

It appears the command succeeded, when it has in fact failed. 