### PR TITLE
Change base metadata for Minids

### DIFF
--- a/minid/minid.py
+++ b/minid/minid.py
@@ -145,7 +145,7 @@ class MinidClient(object):
         namespace = self.TEST_NAMESPACE if test is True else self.NAMESPACE
         metadata = {
             'title': title or filename,
-            'byteCount': os.path.getsize(filename)
+            'length': os.path.getsize(filename)
         }
         checksums = [{
             'function': 'sha256',

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -144,8 +144,8 @@ class MinidClient(object):
         locations = locations or []
         namespace = self.TEST_NAMESPACE if test is True else self.NAMESPACE
         metadata = {
-            '_profile': 'erc',
-            'erc.what': title or filename
+            'title': title or filename,
+            'byteCount': os.path.getsize(filename)
         }
         checksums = [{
             'function': 'sha256',
@@ -175,7 +175,7 @@ class MinidClient(object):
                                 'authorizer.')
         locations, metadata = locations or [], metadata or {}
         if title:
-            metadata['erc.what'] = title
+            metadata['title'] = title
         return self.identifiers_client.update_identifier(minid,
                                                          metadata=metadata,
                                                          location=locations)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ except ImportError:
     from mock import Mock
 
 import fair_research_login
+import globus_sdk
 from minid import MinidClient
 
 from minid.commands import main  # noqa -- ensures commands are loaded
@@ -14,9 +15,11 @@ from minid.commands import main  # noqa -- ensures commands are loaded
 @pytest.fixture
 def logged_in(monkeypatch):
     load_mock = Mock()
-    load_mock.return_value = {}
+    load_mock.return_value = {'auth.globus.org': 'mock_auth_tokens'}
     monkeypatch.setattr(MinidClient, 'is_logged_in', Mock(return_value=True))
     monkeypatch.setattr(fair_research_login.NativeClient, 'load_tokens',
+                        load_mock)
+    monkeypatch.setattr(fair_research_login.NativeClient, 'get_authorizers',
                         load_mock)
     return load_mock
 
@@ -36,6 +39,20 @@ def mock_identifiers_client(monkeypatch):
     mock_identifier = Mock()
     monkeypatch.setattr(MinidClient, 'identifiers_client', mock_identifier)
     return mock_identifier
+
+
+@pytest.fixture
+def mock_globus_sdk_auth(monkeypatch):
+    mock_ac = Mock()
+    monkeypatch.setattr(globus_sdk, 'AuthClient', mock_ac)
+    return mock_ac
+
+
+@pytest.fixture
+def mock_get_cached_created_by(monkeypatch):
+    gccb = Mock(return_value='Test User')
+    monkeypatch.setattr(MinidClient, 'get_cached_created_by', gccb)
+    return gccb
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,8 @@ def test_load_logged_out_authorizer(logged_out):
     assert MinidClient().identifiers_client.authorizer is None
 
 
-def test_register(mock_identifiers_client, mocked_checksum, logged_in):
+def test_register(mock_identifiers_client, mocked_checksum, logged_in,
+                  mock_get_cached_created_by):
     cli = MinidClient()
     cli.register('foo.txt')
 
@@ -24,7 +25,8 @@ def test_register(mock_identifiers_client, mocked_checksum, logged_in):
         'checksums': [{'function': 'sha256', 'value': 'mock_checksum'}],
         'metadata': {
             'title': 'foo.txt',
-            'length': 21
+            'length': 21,
+            'created_by': 'Test User',
         },
         'location': [],
         'namespace': MinidClient.NAMESPACE,
@@ -84,3 +86,16 @@ def test_compute_checksum():
     # Prehashed sum with openssl, file contents "12345"
     checksum = MinidClient.compute_checksum(TEST_CHECKSUM_FILE)
     assert checksum == TEST_CHECKSUM_VALUE
+
+
+def test_get_cached_created_by(mock_globus_sdk_auth, logged_in):
+    mc = MinidClient()
+    mc.get_cached_created_by()
+    assert mock_globus_sdk_auth.called
+
+
+def test_get_cached_created_by_is_cached(mock_globus_sdk_auth, logged_in):
+    mc = MinidClient()
+    mc.get_cached_created_by()
+    mc.get_cached_created_by()
+    assert mock_globus_sdk_auth.call_count == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,8 +23,8 @@ def test_register(mock_identifiers_client, mocked_checksum, logged_in):
     expected = {
         'checksums': [{'function': 'sha256', 'value': 'mock_checksum'}],
         'metadata': {
-            '_profile': 'erc',
-            'erc.what': 'foo.txt'
+            'title': 'foo.txt',
+            'byteCount': 21
         },
         'location': [],
         'namespace': MinidClient.NAMESPACE,
@@ -39,7 +39,7 @@ def test_update(mock_identifiers_client, mocked_checksum, logged_in):
                locations=['http://example.com'])
     mock_identifiers_client.update_identifier.assert_called_with(
         'hdl:20.500.12633/mock-hdl',
-        metadata={'erc.what': 'foo.txt'},
+        metadata={'title': 'foo.txt'},
         location=['http://example.com']
     )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,7 +24,7 @@ def test_register(mock_identifiers_client, mocked_checksum, logged_in):
         'checksums': [{'function': 'sha256', 'value': 'mock_checksum'}],
         'metadata': {
             'title': 'foo.txt',
-            'byteCount': 21
+            'length': 21
         },
         'location': [],
         'namespace': MinidClient.NAMESPACE,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,7 +19,10 @@ def test_load_logged_out_authorizer(logged_out):
 
 
 def test_register(mock_identifiers_client, mocked_checksum, logged_in,
-                  mock_get_cached_created_by):
+                  mock_get_cached_created_by, monkeypatch):
+    stat = Mock()
+    stat.return_value.st_size = 21
+    monkeypatch.setattr(os, 'stat', stat)
     cli = MinidClient()
     cli.register_file('foo.txt')
 


### PR DESCRIPTION
Changed the base metadata from using the old 'erc' fields to new preferred metadata fields. The new metadata automatically creates the following: 
```
{
    "title": "foo.txt",  
    "length": 21,   
    "created_by": "Nickolaus Saint"
}
```