### PR TITLE
Added 'batch-register' from old minid version

### DIFF
--- a/minid/commands/cli.py
+++ b/minid/commands/cli.py
@@ -61,6 +61,8 @@ def execute_command(cli, args, logger):
                         print_separator()
                 else:
                     pretty_print_minid(ret.data)
+        elif subcommand == 'batch-register':
+            print(json.dumps(ret, indent=2))
     except LoginRequired:
         message = 'Authentication required, please login and try again.'
         if args.json:

--- a/minid/commands/minid_ops.py
+++ b/minid/commands/minid_ops.py
@@ -28,6 +28,11 @@ CREATE_UPDATE_ARGS = {
     '--locations': {
         'nargs': '+',
         'help': 'Remotely accessible location(s) for the file'
+    },
+    '--test': {
+        'action': 'store_true',
+        'default': False,
+        'help': 'Register non-permanent Minid in a "test" namespace.'
     }
 }
 
@@ -36,12 +41,7 @@ CREATE_UPDATE_ARGS = {
     [
         shared_argument('--title'),
         shared_argument('--locations'),
-        argument(
-            "--test",
-            action='store_true',
-            default=False,
-            help='Register non-permanent Minid in a "test" namespace.'
-        ),
+        shared_argument('--test'),
         argument(
             "filename",
             help='File to register'
@@ -56,14 +56,30 @@ def register(minid_client, args):
                                  test=args.test, filename=args.filename)
 
 
+@subcommand(
+    [
+        shared_argument('--test'),
+        argument(
+            'filename',
+            help='File to register'
+        ),
+    ],
+    parent=subparsers,
+    shared_arguments=CREATE_UPDATE_ARGS,
+    help='Register a batch of minids from a file or file stream',
+)
+def batch_register(minid_client, args):
+    return minid_client.batch_register(args.filename, args.test)
+
+
 @subcommand([
-    shared_argument('--title'),
-    shared_argument('--locations'),
-    argument(
-        "minid",
-        help='Minid to update'
-    ),
-],
+        shared_argument('--title'),
+        shared_argument('--locations'),
+        argument(
+            "minid",
+            help='Minid to update'
+        ),
+    ],
     parent=subparsers,
     shared_arguments=CREATE_UPDATE_ARGS,
     help='Update an existing Minid'

--- a/minid/commands/minid_ops.py
+++ b/minid/commands/minid_ops.py
@@ -52,8 +52,12 @@ CREATE_UPDATE_ARGS = {
     help='Register a new Minid',
 )
 def register(minid_client, args):
-    return minid_client.register(title=args.title, locations=args.locations,
-                                 test=args.test, filename=args.filename)
+    return minid_client.register_file(
+        args.filename,
+        title=args.title,
+        locations=args.locations,
+        test=args.test
+    )
 
 
 @subcommand(

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -18,6 +18,7 @@ import logging
 import json
 from collections import OrderedDict
 import hashlib
+import datetime
 
 import fair_research_login
 from identifiers_client.identifiers_api import IdentifierClient
@@ -225,18 +226,12 @@ class MinidClient(object):
     def get_most_recent_active_entity(self, entities):
         """If there are multiple entities, return the entity with the latest
         timestamp."""
-        if len(entities.data['identifiers']) > 0:
-            return entities.data['identifiers'][-1]
-        return None
-        # HACK! Currently the date created is not returned, so we can't get the
-        # time for each identifier. Simply return the last one in the list the
-        # server generates.
-        # active_sorted = sorted(entities,
-        #                        key=lambda x: datetime.datetime.strptime(
-        #                            x["created"], '%Y-%m-%dT%H:%M:%S.%f'),
-        #                        reverse=True)
-        # if active_sorted:
-        #     return active_sorted[0]
+        active_sorted = sorted(entities,
+                               key=lambda x: datetime.datetime.strptime(
+                                   x["created"], '%Y-%m-%dT%H:%M:%S.%f'),
+                               reverse=True)
+        if active_sorted:
+            return active_sorted[0]
 
     @staticmethod
     def _is_stream(file_handle):
@@ -327,9 +322,9 @@ class MinidClient(object):
         # recent hashes for that record.
         entity = None
         for checksum in searchable_checksums:
-            existing_entities = self.identifiers_client.\
-                get_identifier_by_checksum(checksum)
-            entity = self.get_most_recent_active_entity(existing_entities)
+            exst = self.identifiers_client.get_identifier_by_checksum(checksum)
+            minids = exst.data.get('identifiers', [])
+            entity = self.get_most_recent_active_entity(minids)
             if entity:
                 break
         if not entity:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,14 @@ import pytest
 import os
 import json
 
-from mock import Mock, mock_open, patch
+from unittest.mock import Mock, mock_open, patch
 
 import fair_research_login
 from minid import MinidClient
 
-TEST_RFM = os.path.join(os.path.dirname(__file__), 'files',
-                        'mock_remote_file_manifest.json')
+BASE_DIR = os.path.join(os.path.dirname(__file__), 'files')
+TEST_RFM = os.path.join(BASE_DIR, 'mock_remote_file_manifest.json')
+MOCK_IDENTIFIERS = os.path.join(BASE_DIR, 'mock_identifiers_response.json')
 
 from minid.commands import main  # noqa -- ensures commands are loaded
 
@@ -53,7 +54,8 @@ def mock_gcs_register(mock_identifiers_client, mock_globus_response):
 @pytest.fixture
 def mock_gcs_get_by_checksum(mock_identifiers_client, mock_globus_response):
     mock_globus_response = mock_globus_response()
-    mock_globus_response.data = {'identifiers': []}
+    with open(MOCK_IDENTIFIERS) as f:
+        mock_globus_response.data = json.load(f)
     mock_identifiers_client.get_identifier_by_checksum.return_value = \
         mock_globus_response
     return mock_identifiers_client.get_identifier_by_checksum

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
 import pytest
+import os
+import json
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
+from mock import Mock, mock_open, patch
 
 import fair_research_login
 from minid import MinidClient
+
+TEST_RFM = os.path.join(os.path.dirname(__file__), 'files',
+                        'mock_remote_file_manifest.json')
 
 from minid.commands import main  # noqa -- ensures commands are loaded
 
@@ -35,7 +37,26 @@ def logged_out(monkeypatch):
 def mock_identifiers_client(monkeypatch):
     mock_identifier = Mock()
     monkeypatch.setattr(MinidClient, 'identifiers_client', mock_identifier)
+
     return mock_identifier
+
+
+@pytest.fixture
+def mock_gcs_register(mock_identifiers_client, mock_globus_response):
+    mock_globus_response = mock_globus_response()
+    mock_globus_response.data = {'identifier': 'newly_minted_identifier'}
+    mock_identifiers_client.create_identifier.return_value = \
+        mock_globus_response
+    return mock_identifiers_client.create_identifier
+
+
+@pytest.fixture
+def mock_gcs_get_by_checksum(mock_identifiers_client, mock_globus_response):
+    mock_globus_response = mock_globus_response()
+    mock_globus_response.data = {'identifiers': []}
+    mock_identifiers_client.get_identifier_by_checksum.return_value = \
+        mock_globus_response
+    return mock_identifiers_client.get_identifier_by_checksum
 
 
 @pytest.fixture
@@ -43,3 +64,27 @@ def mocked_checksum(monkeypatch):
     mock_cc = Mock(return_value='mock_checksum')
     monkeypatch.setattr(MinidClient, 'compute_checksum', mock_cc)
     return mock_cc
+
+
+@pytest.fixture
+def mock_rfm():
+    with open(TEST_RFM) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def mock_globus_response():
+    class MockGlobusSDKResponse(object):
+        def __init__(self):
+            self.data = {}
+
+        def __getitem__(self, val):
+            return self.data[val]
+    return MockGlobusSDKResponse
+
+
+@pytest.yield_fixture
+def mock_streamed_rfm(mock_rfm):
+    text = '\n'.join([json.dumps(l) for l in mock_rfm])
+    with patch('builtins.open', mock_open(read_data=text)) as mocked_open:
+        yield mocked_open

--- a/tests/files/mock_identifiers_response.json
+++ b/tests/files/mock_identifiers_response.json
@@ -1,0 +1,45 @@
+{"identifiers": [
+{
+  "admins": [],
+  "checksums": [
+    {
+      "function": "sha256",
+      "value": "6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06"
+    }
+  ],
+  "created": "2020-03-03T16:48:03.463187",
+  "identifier": "hdl:20.500.12633/foo-identifier",
+  "landing_page": "https://identifiers.fair-research.org/hdl:20.500.12633/foo.txt",
+  "location": [],
+  "metadata": {
+    "_profile": "erc",
+    "erc.what": "foo.txt"
+  },
+  "updated": "2020-03-03T16:48:03.463187",
+  "visible_to": [
+    "public"
+  ]
+},
+{
+  "admins": [],
+  "checksums": [
+    {
+      "function": "sha256",
+      "value": "6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06"
+    }
+  ],
+  "created": "2020-05-03T16:48:03.463187",
+  "identifier": "hdl:20.500.12633/bar-identifier",
+  "landing_page": "https://identifiers.fair-research.org/hdl:20.500.12633/bar.txt",
+  "location": [],
+  "metadata": {
+    "_profile": "erc",
+    "erc.what": "bar.txt"
+  },
+  "updated": "2020-05-03T16:48:03.463187",
+  "visible_to": [
+    "public"
+  ]
+}
+]
+}

--- a/tests/files/mock_remote_file_manifest.json
+++ b/tests/files/mock_remote_file_manifest.json
@@ -1,0 +1,12 @@
+[
+    {
+        "url": "https://example.com/foo.txt",
+        "sha256": "6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06",
+        "filename": "foo.txt"
+    },
+    {
+        "url": "https://example.com/bar.txt",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "filename": "bar.txt"
+    }
+]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,8 +6,9 @@ from minid.exc import MinidException
 
 from unittest.mock import Mock
 
-TEST_CHECKSUM_FILE = os.path.join(os.path.dirname(__file__), 'files',
-                                  'test_compute_checksum.txt')
+FILES_DIR = os.path.join(os.path.dirname(__file__), 'files')
+TEST_RFM_FILE = os.path.join(FILES_DIR, 'mock_remote_file_manifest.json')
+TEST_CHECKSUM_FILE = os.path.join(FILES_DIR, 'test_compute_checksum.txt')
 TEST_CHECKSUM_VALUE = ('5994471abb01112afcc18159f6cc74b4'
                        'f511b99806da59b3caf5a9c173cacfc5')
 
@@ -16,9 +17,9 @@ def test_load_logged_out_authorizer(logged_out):
     assert MinidClient().identifiers_client.authorizer is None
 
 
-def test_register(mock_identifiers_client, mocked_checksum, logged_in):
+def test_register_file(mock_identifiers_client, mocked_checksum, logged_in):
     cli = MinidClient()
-    cli.register('foo.txt')
+    cli.register_file('foo.txt')
 
     expected = {
         'checksums': [{'function': 'sha256', 'value': 'mock_checksum'}],
@@ -31,6 +32,47 @@ def test_register(mock_identifiers_client, mocked_checksum, logged_in):
         'visible_to': ['public']
     }
     assert expected in mock_identifiers_client.create_identifier.call_args
+
+
+def test_register_unsupported_checksum(mock_identifiers_client, logged_in):
+    cli = MinidClient()
+    checksums = [{'function': 'sha256', 'value': 'mock_checksum'},
+                 {'function': 'NOT_REAL', 'value': 'irrelevant!'}]
+    cli.register(checksums, title='foo.txt')
+
+    expected = {
+        'checksums': [{'function': 'sha256', 'value': 'mock_checksum'}],
+        'metadata': {'erc.what': 'foo.txt'},
+        'location': [],
+        'namespace': MinidClient.NAMESPACE,
+        'visible_to': ['public']
+    }
+    assert expected in mock_identifiers_client.create_identifier.call_args
+
+
+def test_get_or_register_manifest_entity(
+        mock_rfm, logged_in, mock_gcs_get_by_checksum, mock_gcs_register):
+    cli = MinidClient()
+    cli.get_or_register_rfm(mock_rfm[0], True)
+    assert mock_gcs_register.called
+    assert mock_gcs_get_by_checksum.called
+
+
+def test_get_or_register_manifest_entity_with_preregistered(
+        mock_rfm, logged_in, mock_gcs_get_by_checksum, mock_gcs_register):
+    resp = {'identifiers': [{'identifier': 'pre-registered'}]}
+    mock_gcs_get_by_checksum.return_value.data = resp
+    cli = MinidClient()
+    cli.get_or_register_rfm(mock_rfm[0], True)
+    assert mock_gcs_register.called is False
+    assert mock_gcs_get_by_checksum.called
+
+
+def test_batch_register(monkeypatch, logged_in, mock_rfm, mock_gcs_register,
+                        mock_gcs_get_by_checksum):
+    cli = MinidClient()
+    cli.batch_register(TEST_RFM_FILE, True)
+    assert mock_gcs_register.call_count == len(mock_rfm)
 
 
 def test_update(mock_identifiers_client, mocked_checksum, logged_in):
@@ -84,3 +126,26 @@ def test_compute_checksum():
     # Prehashed sum with openssl, file contents "12345"
     checksum = MinidClient.compute_checksum(TEST_CHECKSUM_FILE)
     assert checksum == TEST_CHECKSUM_VALUE
+
+
+def test_read_manifest_entries(mock_rfm):
+    read_rfm = list(MinidClient.read_manifest_entries(TEST_RFM_FILE))
+    assert read_rfm == mock_rfm
+
+
+def test_is_stream(mock_streamed_rfm):
+    with open('magic_file.json', 'r') as manifest:
+        assert MinidClient._is_stream(manifest) is True
+
+
+def test_is_not_stream():
+    with open(TEST_RFM_FILE, 'r') as manifest:
+        assert MinidClient._is_stream(manifest) is False
+
+
+def test_read_manifest_entries_streamed(mock_streamed_rfm, mock_rfm,
+                                        monkeypatch):
+    monkeypatch.setattr(MinidClient, '_is_stream', Mock(return_value=True))
+    read_rfm = list(MinidClient.read_manifest_entries('rfm.json'))
+    assert len(read_rfm) == len(mock_rfm)
+    assert read_rfm == mock_rfm

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,6 +68,17 @@ def test_get_or_register_manifest_entity_with_preregistered(
     assert mock_gcs_get_by_checksum.called
 
 
+def test_get_oor_register_manifest_entry_with_no_matching_hashes(
+        mock_rfm, logged_in, mock_gcs_get_by_checksum, mock_gcs_register):
+    record = mock_rfm[0]
+    del record['sha256']
+    record['sha512'] = 'abcdefg_sha512hash_hijklmnop'
+    cli = MinidClient()
+    cli.get_or_register_rfm(record, True)
+    assert mock_gcs_register.called
+    assert mock_gcs_get_by_checksum.called
+
+
 def test_batch_register(monkeypatch, logged_in, mock_rfm, mock_gcs_register,
                         mock_gcs_get_by_checksum):
     cli = MinidClient()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -38,9 +38,8 @@ LOGGED_IN_COMMANDS = [
     }),
     ({
         'command': ['register', 'foo.txt'],
-        'mock': (minid.MinidClient, 'register'),
-        'expected_call_args': ([], {
-            'filename': 'foo.txt',
+        'mock': (minid.MinidClient, 'register_file'),
+        'expected_call_args': (['foo.txt'], {
             'locations': None,
             'test': False,
             'title': None
@@ -48,9 +47,8 @@ LOGGED_IN_COMMANDS = [
     }),
     ({
         'command': ['--json', 'register', 'foo.txt'],
-        'mock': (minid.MinidClient, 'register'),
-        'expected_call_args': ([], {
-            'filename': 'foo.txt',
+        'mock': (minid.MinidClient, 'register_file'),
+        'expected_call_args': (['foo.txt'], {
             'locations': None,
             'test': False,
             'title': None
@@ -58,9 +56,8 @@ LOGGED_IN_COMMANDS = [
     }),
     ({
         'command': ['register', '--test', 'foo.txt'],
-        'mock': (minid.MinidClient, 'register'),
-        'expected_call_args': ([], {
-            'filename': 'foo.txt',
+        'mock': (minid.MinidClient, 'register_file'),
+        'expected_call_args': (['foo.txt'], {
             'locations': None,
             'test': True,
             'title': None
@@ -71,9 +68,8 @@ LOGGED_IN_COMMANDS = [
             'register', 'foo.txt', '--locations', 'http://example.com',
             'http://foo.example.com'
         ],
-        'mock': (minid.MinidClient, 'register'),
-        'expected_call_args': ([], {
-            'filename': 'foo.txt',
+        'mock': (minid.MinidClient, 'register_file'),
+        'expected_call_args': (['foo.txt'], {
             'locations': [
                 'http://example.com', 'http://foo.example.com'
             ],
@@ -83,9 +79,8 @@ LOGGED_IN_COMMANDS = [
     }),
     ({
         'command': ['register', 'foo.txt', '--title', 'My Foo'],
-        'mock': (minid.MinidClient, 'register'),
-        'expected_call_args': ([], {
-            'filename': 'foo.txt',
+        'mock': (minid.MinidClient, 'register_file'),
+        'expected_call_args': (['foo.txt'], {
             'locations': None,
             'test': False,
             'title': 'My Foo'


### PR DESCRIPTION
~~EDIT: The changes are functional and nearly good to go. The last remaining item is having the minid service return the date identifiers were created, so that the client can compare identifiers returned when searching by checksum. Currently, there is a hack in place to simply fetch the last one in the list.~~

**EDIT 2**: This has been finished, changes are ready! 

This allows for registering a bunch of minids based on data in a remote file manifest. 

The changes are functional, but I'm sure there are bugs. I still need to write tests. The basics work though: 

Given the RFM:
```
[
    {
        "url": "https://example.com/foo.txt",
        "sha256": "6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06",
        "filename": "foo.txt"
    },
    {
        "url": "https://example.com/bar.txt",
        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
        "filename": "bar"
    }
]
```

Run the following `batch-register`:
```
%  minid --verbose batch-register myman.json --test
Parsing file from filename myman.json
Checking entry foo.txt
Authorizer: <globus_sdk.authorizers.access_token.AccessTokenAuthorizer object at 0x109348d90>
Entity already registered, using hdl:20.500.12633/SqjNl43zsQaL for foo.txt.
Checking entry bar
Authorizer: <globus_sdk.authorizers.access_token.AccessTokenAuthorizer object at 0x1092eef10>
Authorizer: <globus_sdk.authorizers.access_token.AccessTokenAuthorizer object at 0x1092ff940>
[
  {
    "url": "hdl:20.500.12633/SqjNl43zsQaL",
    "sha256": "6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06",
    "filename": "foo.txt"
  },
  {
    "url": "hdl:20.500.12633/Z9kkoXXgPW9a",
    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
    "filename": "bar"
  }
]
```