### PR TITLE
Added back earlier feature to translate compatible identifiers to minids

### DIFF
--- a/minid/exc.py
+++ b/minid/exc.py
@@ -8,3 +8,8 @@ class MinidException(Exception):
 class LoginRequired(MinidException):
     """An exception happened because a login is required"""
     pass
+
+
+class UnknownIdentifier(MinidException):
+    """The given identifier is not a known type in the Minid ecosystem."""
+    pass

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -196,7 +196,8 @@ class MinidClient(object):
           be treated as a file.
         """
         if self.is_valid_identifier(entity):
-            return self.identifiers_client.get_identifier(entity)
+            hdl = self.to_identifier(entity, 'hdl')
+            return self.identifiers_client.get_identifier(hdl)
         else:
             alg = self.get_algorithm(algorithm)
             checksum = self.compute_checksum(entity, alg)

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -243,17 +243,23 @@ class MinidClient(object):
 
     @classmethod
     def is_valid_identifier(cls, identifier):
+        """Returns True if the identifier is known and can be resolved by Minid
+        """
         return bool(cls.get_identifier_prefix(identifier))
 
     @classmethod
     def get_identifier_prefix(cls, identifier):
-        """Fetch the namespace part of the identifier, which will be the
-        leading characters of the identifier. Examples include:
-        * "minid:"
-        * "minid.test:"
-        * "hdl:20.500.12633"
-        * "hld:20.500.12582"
-        Returns the prefix
+        """Returns the prefix for the given identifier. Checks in both the
+        normal prefixes and the test prefixes.
+        ** Parameters **
+          ``identifier`` (*string*) A Minid compatible identifier. Ex:
+          minid:foobarbaz
+        ** Returns **
+        The prefix for the given identifer. Examples
+          * "minid:"
+          * "minid.test:"
+          * "hdl:20.500.12633"
+          * "hld:20.500.12582"
         """
         prefixes = (list(cls.PREFIXES.values()) +
                     list(cls.PREFIXES_TEST.values()))
@@ -262,11 +268,26 @@ class MinidClient(object):
 
     @classmethod
     def is_test(cls, identifier):
+        """Returns true if the identifier exists within the test namespace"""
         return any([identifier.startswith(idpx)
                     for idpx in cls.PREFIXES_TEST.values()])
 
     @classmethod
     def to_identifier(cls, identifier, identifier_type='hdl'):
+        """Returns the prefix for the given identifier. Checks in both the
+        normal prefixes and the test prefixes.
+        ** Parameters **
+          ``identifier`` (*string*) A Minid compatible identifier. Ex:
+          minid:foobarbaz
+          ``identifier_type`` (*string*) The preferred type of identifier to
+          translate the given *identifier*.
+        ** Returns **
+        The translated identifier as a string type. Examples:
+          * "minid:foobarbaz"
+          * "minid.test:foobarbaz"
+          * "hdl:20.500.12633/foobarbaz"
+          * "hld:20.500.12582/foobarbaz"
+        """
         if identifier_type not in cls.PREFIXES:
             raise UnknownIdentifier(f'Identifier type {identifier_type} is '
                                     'not supported by Minid.')
@@ -282,8 +303,7 @@ class MinidClient(object):
 
     @classmethod
     def to_minid(cls, identifier):
-        """Return a Minid from the given Identifier. The Identifier must be of
-        a type supported by Minid. Check the docs for a full list of supported
-        types.
+        """Convenience method. Calls (to_identifier(identifier, 'minid').
+        Returns the given identifier as a Minid.
         """
         return cls.to_identifier(identifier, identifier_type='minid')

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -39,10 +39,12 @@ class MinidClient(object):
     PREFIXES = {
         'minid': 'minid:',
         'hdl': 'hdl:20.500.12582/',
+        'ark': 'ark:/57799/',
     }
     PREFIXES_TEST = {
         'minid': 'minid.test:',
-        'hdl': 'hdl:20.500.12633/'
+        'hdl': 'hdl:20.500.12633/',
+        'ark': 'ark:/99999/',
     }
 
     def __init__(self, authorizer=None, app_name=None, native_client=None,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -30,7 +30,7 @@ def mock_auth_logout(monkeypatch):
 
 
 @pytest.fixture(params=['register', 'update'])
-def minid_auth_required_op(request):
+def minid_auth_required_op(request, logged_out):
     return request.param
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 import pytest
 import hashlib
 import os
+import sys
 from minid.minid import MinidClient
 from minid.exc import MinidException
 
@@ -180,6 +181,8 @@ def test_is_not_stream():
         assert MinidClient._is_stream(manifest) is False
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6),
+                    reason="requires python3.6 or higher")
 def test_read_manifest_entries_streamed(mock_streamed_rfm, mock_rfm,
                                         monkeypatch):
     monkeypatch.setattr(MinidClient, '_is_stream', Mock(return_value=True))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,7 @@ def test_register(mock_identifiers_client, mocked_checksum, logged_in):
             'erc.what': 'foo.txt'
         },
         'location': [],
-        'namespace': MinidClient.NAMESPACE,
+        'namespace': MinidClient.IDENTIFIERS_NAMESPACE,
         'visible_to': ['public']
     }
     assert expected in mock_identifiers_client.create_identifier.call_args

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -181,8 +181,8 @@ def test_is_not_stream():
         assert MinidClient._is_stream(manifest) is False
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6),
-                    reason="requires python3.6 or higher")
+@pytest.mark.skipif(sys.version_info > (3, 6) and sys.version_info < (3, 7),
+                    reason='Skip if python 3.6')
 def test_read_manifest_entries_streamed(mock_streamed_rfm, mock_rfm,
                                         monkeypatch):
     monkeypatch.setattr(MinidClient, '_is_stream', Mock(return_value=True))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -231,7 +231,8 @@ def test_command_requires_login_json_output(monkeypatch, logged_in,
                                             mock_ic_error):
     register_mock = Mock()
     register_mock.side_effect = mock_ic_error
-    monkeypatch.setattr(minid.minid.MinidClient, 'register', register_mock)
+    monkeypatch.setattr(minid.minid.MinidClient, 'register_file',
+                        register_mock)
 
     log = Mock()
     args = cli.cli.parse_args(['--json', 'register', '--test', 'foo.txt'])
@@ -259,7 +260,8 @@ def test_command_general_identifiers_error(monkeypatch, logged_in,
     mock_ic_error.http_status = 500
     register_mock = Mock()
     register_mock.side_effect = mock_ic_error
-    monkeypatch.setattr(minid.minid.MinidClient, 'register', register_mock)
+    monkeypatch.setattr(minid.minid.MinidClient, 'register_file',
+                        register_mock)
 
     log = Mock()
     args = cli.cli.parse_args(['--verbose', 'register', '--test', 'foo.txt'])

--- a/tests/test_identifier_translation.py
+++ b/tests/test_identifier_translation.py
@@ -1,0 +1,61 @@
+import pytest
+
+import minid
+
+PROD_HDL = 'hdl:20.500.12582/prod_ident_xyz'
+TEST_HDL = 'hdl:20.500.12633/test_ident_xyz'
+PROD_MINID = 'minid:prod_ident_xyz'
+TEST_MINID = 'minid.test:test_ident_xyz'
+
+# The ordering is ('identifier', 'to_type', 'expected_result')
+VALID_MINID_TRANSLATIONS = [
+    (PROD_HDL, 'minid', PROD_MINID),
+    (PROD_HDL, 'hdl', PROD_HDL),
+    (TEST_HDL, 'minid', TEST_MINID),
+    (TEST_HDL, 'hdl', TEST_HDL),
+
+    (PROD_MINID, 'minid', PROD_MINID),
+    (PROD_MINID, 'hdl', PROD_HDL),
+    (TEST_MINID, 'minid', TEST_MINID),
+    (TEST_MINID, 'hdl', TEST_HDL),
+]
+
+INVALID_MINID_TRANSLATIONS = [
+    ('invalid_ident:3.141.59/', 'minid', minid.exc.UnknownIdentifier),
+    ('invalid_ident:3.141.59/', 'hdl', minid.exc.UnknownIdentifier),
+
+    (PROD_HDL, 'does-not-exist', minid.exc.UnknownIdentifier),
+    (TEST_MINID, 'does-not-exist', minid.exc.UnknownIdentifier),
+]
+
+
+@pytest.fixture(params=VALID_MINID_TRANSLATIONS)
+def valid_minid_translation(request):
+    return request.param
+
+
+@pytest.fixture(params=INVALID_MINID_TRANSLATIONS)
+def invalid_minid_translation(request):
+    return request.param
+
+
+@pytest.fixture(params=[(PROD_HDL, PROD_MINID), (TEST_HDL, TEST_MINID)])
+def valid_to_minid(request):
+    return request.param
+
+
+def test_valid_minid_translation(valid_minid_translation):
+    ident, to_type, expected = valid_minid_translation
+    result = minid.MinidClient.to_identifier(ident, identifier_type=to_type)
+    assert result == expected
+
+
+def test_invalid_minid_translation(invalid_minid_translation):
+    ident, to_type, exc = invalid_minid_translation
+    with pytest.raises(exc):
+        minid.MinidClient.to_identifier(ident, identifier_type=to_type)
+
+
+def test_valid_to_minid(valid_to_minid):
+    ident, expected = valid_to_minid
+    assert minid.MinidClient.to_minid(ident) == expected


### PR DESCRIPTION
Enables the following:

```
minid check ark:/57799/b9Q82mN8DT4Dib
minid check minid:b9Q82mN8DT4Dib
minid check hdl:20.500.12582/b9Q82mN8DT4Dib
```

Also works for test namespaces:

```
$ minid check minid.test:SqjNl43zsQaL

Minid:               hdl:20.500.12633/SqjNl43zsQaL
Title:               foo.txt
Checksums:           6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06 (sha256)
Created:             
Landing Page:        https://identifiers.fair-research.org/hdl:20.500.12633/SqjNl43zsQaL
EZID Landing Page:   https://ezid.cdlib.org/id/hdl:20.500.12633/SqjNl43zsQaL
Locations:           

```