### PR TITLE
Fixed handling of file-not-found bug.

### DIFF
--- a/minid/commands/cli.py
+++ b/minid/commands/cli.py
@@ -77,7 +77,7 @@ def execute_command(cli, args, logger):
             if ice.raw_json and ice.raw_json.get('message'):
                 error = ice.raw_json['message']
             log.error(error)
-    except MinidException as me:
+    except (MinidException, FileNotFoundError) as me:
         if args.json:
             print(json.dumps({'error': str(me)}))
         else:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -255,6 +255,16 @@ def test_cli_errors(logged_out):
     cli.execute_command(cli, args, Mock())
 
 
+def test_file_not_found(logged_in, monkeypatch):
+    log = Mock()
+    monkeypatch.setattr(cli, 'log', log)
+    args = cli.cli.parse_args(['register', 'not_found.txt'])
+    cli.execute_command(cli, args, Mock())
+    assert log.error.called
+    assert isinstance(log.error.call_args.args[0],
+                      FileNotFoundError)
+
+
 def test_command_general_identifiers_error(monkeypatch, logged_in,
                                            mock_ic_error):
     mock_ic_error.http_status = 500

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -261,8 +261,6 @@ def test_file_not_found(logged_in, monkeypatch):
     args = cli.cli.parse_args(['register', 'not_found.txt'])
     cli.execute_command(cli, args, Mock())
     assert log.error.called
-    assert isinstance(log.error.call_args.args[0],
-                      FileNotFoundError)
 
 
 def test_command_general_identifiers_error(monkeypatch, logged_in,


### PR DESCRIPTION
Previously, Minid would produce an 'unexpected error' when an invalid filename was passed in. The CLI now expects that error and ensures it is properly displayed to the user. 