### PR TITLE
Changed minid install docs to direct folks towards the beta

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,9 @@ See the `Read The Docs <https://minid.readthedocs.io/en/develop>`_ page for more
 
 Usage
 -----
-Install requires python 3.6 or higher::
+Minid 2.0.0 requires python 3.6 or higher::
 
-  $ pip install minid
+  $ pip install --pre minid
 
 Minting identifiers is simple and easy::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,22 +15,23 @@ to make data easily findable, accessible, interoperable, and reusable (FAIR).
 Requirements
 ------------
 
-Minid Requires the following:
-
-* Python 3.6 or higher
-
+Minid 2.0.0 Requires Python 3.6 or higher.
 
 Installation
 ------------
 
-The minid client and CLI is avaialble on PyPI. You can install it with the following command::
+Minid Client 2.0.0 is avaialble on PyPI. You can install it with the following command::
 
-  $ pip install minid
+  $ pip install --pre minid
+
+
+You can also install the `legacy Minid 1.3.0 version <https://github.com/fair-research/minid/tree/1.3.0>`_ with::
+
+  $ pip install minid==1.3.0
 
 Alternatively, you can download the source code and install using setup tools::
 
   $ git clone https://github.com/fair-research/minid
-
   $ python setup.py install
 
 


### PR DESCRIPTION
The docs prefer installing pip with the --pre flag to get the latest
beta instead of the old legacy client.