### PR TITLE
Tombstoning

### DIFF
--- a/minid/commands/argparse_ext.py
+++ b/minid/commands/argparse_ext.py
@@ -31,6 +31,19 @@ def shared_argument(arg):
     return arg
 
 
+def parse_none_values(values, none_value='None'):
+    """Do the things to the options"""
+    options = {}
+    for option_name, option_value, option_none_value in values:
+        if isinstance(option_value, str) and option_value == none_value:
+            options[option_name] = option_none_value
+        elif isinstance(option_value, list) and option_value == [none_value]:
+            options[option_name] = option_none_value
+        elif option_value:
+            options[option_name] = option_value
+    return options
+
+
 def subcommand(args, parent, **kwargs):
     def decorator(func):
         shared_args = kwargs.pop('shared_arguments', {})

--- a/minid/commands/cli.py
+++ b/minid/commands/cli.py
@@ -161,7 +161,7 @@ def pretty_print_minid(cli, command_json):
         },
         {
             'title': 'Active',
-            'func': lambda m: m.get('active')
+            'func': lambda m: m.get('active') or 'False'
         },
         {
             'title': 'Replaces',

--- a/minid/commands/cli.py
+++ b/minid/commands/cli.py
@@ -27,6 +27,7 @@ from minid.exc import MinidException, LoginRequired
 
 import minid
 
+SERVICE_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 DATE_FORMAT = '%A, %B %d, %Y %H:%M:%S %Z'
 
 cli = ArgumentParser()
@@ -102,7 +103,7 @@ def print_date(iso_datestring):
     """Pretty print dates in user's local time zone"""
     if not iso_datestring:
         return ''
-    dt = datetime.datetime.fromisoformat(iso_datestring)
+    dt = datetime.datetime.strptime(iso_datestring, SERVICE_DATE_FORMAT)
     user_tz = pytz.timezone(tzlocal.get_localzone().zone)
     dt_local = user_tz.fromutc(dt)
     return dt_local.strftime(DATE_FORMAT)

--- a/minid/commands/minid_ops.py
+++ b/minid/commands/minid_ops.py
@@ -57,12 +57,15 @@ CREATE_UPDATE_ARGS = {
     help='Register a new Minid',
 )
 def register(minid_client, args):
+    kwargs = dict()
+    if args.replaces:
+        kwargs['replaces'] = args.replaces
     return minid_client.register_file(
         args.filename,
         title=args.title,
         locations=args.locations,
         test=args.test,
-        replaces=args.replaces,
+        **kwargs
     )
 
 
@@ -106,11 +109,12 @@ def update(minid_client, args):
         raise MinidException('Cannot use both --set-active and --set-inactive')
     if args.set_active or args.set_inactive:
         kwargs['active'] = True if args.set_active else False
+    # Include other kwargs, but only if they have been set by the user.
+    for arg in [args.replaces, args.replaced_by]:
+        if arg:
+            kwargs[arg.__name__] = arg
     return minid_client.update(args.minid, title=args.title,
-                               locations=args.locations,
-                               replaces=args.replaces,
-                               replaced_by=args.replaced_by,
-                               **kwargs)
+                               locations=args.locations, **kwargs)
 
 
 @subcommand(

--- a/minid/commands/minid_ops.py
+++ b/minid/commands/minid_ops.py
@@ -18,6 +18,7 @@ import logging
 
 from minid.commands.cli import subparsers
 from minid.commands.argparse_ext import subcommand, argument, shared_argument
+from minid.exc import MinidException
 
 log = logging.getLogger(__name__)
 
@@ -84,8 +85,10 @@ def batch_register(minid_client, args):
 @subcommand([
         shared_argument('--title'),
         shared_argument('--locations'),
-        argument('--active', action='store_true',
-                 help='Set minid active or inactive'),
+        argument('--set-active', action='store_true',
+                 help='Set minid active.'),
+        argument('--set-inactive', action='store_true',
+                 help='Set minid inactive'),
         argument('--replaced-by'),
         shared_argument('--replaces'),
         argument(
@@ -98,8 +101,16 @@ def batch_register(minid_client, args):
     help='Update an existing Minid'
 )
 def update(minid_client, args):
+    kwargs = dict()
+    if args.set_active and args.set_inactive:
+        raise MinidException('Cannot use both --set-active and --set-inactive')
+    if args.set_active or args.set_inactive:
+        kwargs['active'] = True if args.set_active else False
     return minid_client.update(args.minid, title=args.title,
-                               locations=args.locations)
+                               locations=args.locations,
+                               replaces=args.replaces,
+                               replaced_by=args.replaced_by,
+                               **kwargs)
 
 
 @subcommand(

--- a/minid/commands/minid_ops.py
+++ b/minid/commands/minid_ops.py
@@ -33,7 +33,10 @@ CREATE_UPDATE_ARGS = {
         'action': 'store_true',
         'default': False,
         'help': 'Register non-permanent Minid in a "test" namespace.'
-    }
+    },
+    '--replaces': {
+        'help': 'This Minid replaces another Minid'
+    },
 }
 
 
@@ -42,6 +45,7 @@ CREATE_UPDATE_ARGS = {
         shared_argument('--title'),
         shared_argument('--locations'),
         shared_argument('--test'),
+        shared_argument('--replaces'),
         argument(
             "filename",
             help='File to register'
@@ -56,7 +60,8 @@ def register(minid_client, args):
         args.filename,
         title=args.title,
         locations=args.locations,
-        test=args.test
+        test=args.test,
+        replaces=args.replaces,
     )
 
 
@@ -79,6 +84,10 @@ def batch_register(minid_client, args):
 @subcommand([
         shared_argument('--title'),
         shared_argument('--locations'),
+        argument('--active', action='store_true',
+                 help='Set minid active or inactive'),
+        argument('--replaced-by'),
+        shared_argument('--replaces'),
         argument(
             "minid",
             help='Minid to update'

--- a/minid/commands/minid_ops.py
+++ b/minid/commands/minid_ops.py
@@ -110,11 +110,13 @@ def update(minid_client, args):
     if args.set_active or args.set_inactive:
         kwargs['active'] = True if args.set_active else False
     # Include other kwargs, but only if they have been set by the user.
-    for arg in [args.replaces, args.replaced_by]:
-        if arg:
-            kwargs[arg.__name__] = arg
-    return minid_client.update(args.minid, title=args.title,
-                               locations=args.locations, **kwargs)
+    for name, value in [('replaces', args.replaces),
+                        ('replaced_by', args.replaced_by)]:
+        if value:
+            kwargs[name] = value
+    if args.locations:
+        kwargs['locations'] = args.locations
+    return minid_client.update(args.minid, title=args.title, **kwargs)
 
 
 @subcommand(

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -177,7 +177,8 @@ class MinidClient(object):
           ``replaces`` (* string *)
           ID of another identifier to replace
         ** Returns **
-
+        A dict describing attributes of the identifier.
+        See ``register`` for an example of the output.
         """
         if not self.is_logged_in():
             raise LoginRequired('The Minid Client did not have a valid '
@@ -199,7 +200,51 @@ class MinidClient(object):
     def register(self, checksums, title='', locations=None, test=False,
                  metadata=None, **kwargs):
         """Register pre-prepared data, where the checksum already exists for
-        a given file."""
+        a given file.
+        ** Parameters **
+          ``checksums`` (*list of dicts*)
+          A list of dicts containing checksums. Example:
+          [{'function': 'sha256', 'value': 'computed sha256 checksum'},]
+          ``title`` (* string *)
+          The title used to refer to the minid. Defaults to filename
+          ``locations`` (* array of strings *)
+          Network accessible locations for the given file
+          ``test`` (* boolean *)
+          Create the minid in a non-permanent test namespace
+          ``metadata`` (* dict *)
+          A dictionary containing extra metadata about the identifier. 'title'
+          is set by given ``title`` and created_by is by default the logged-in
+          user.
+          ``replaces`` (* string *)
+          ID of another identifier to replace
+        ** Returns **
+        A Dict describing the identifier. Example:
+        {
+          "active": true,
+          "admins": ['identities-of-admins'],
+          "checksums": [
+            {
+              "function": "sha256",
+              "value": "checksum"
+            }
+          ],
+          "created": "2020-04-08T14:17:53.212592",
+          "identifier": "hdl:20.500.12633/1234567",
+          "landing_page": "https://identifiers.fair-research.org/minid",
+          "location": [],
+          "metadata": {
+            "created_by": "The Creator",
+            "length": 76,
+            "title": "foo.txt"
+          },
+          "replaced_by": "hdl:20.500.12633/456",
+          "replaces": "hdl:20.500.12633/789",
+          "updated": "2020-04-08T15:26:25.256145",
+          "visible_to": [
+            "public"
+          ]
+        }
+        """
         if not self.is_logged_in():
             raise LoginRequired('The Minid Client did not have a valid '
                                 'authorizer.')

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -254,7 +254,8 @@ class MinidClient(object):
         locations, metadata = locations or [], metadata or {}
         if title:
             metadata['title'] = title
-        return self.identifiers_client.update_identifier(minid,
+        identifier = self.to_identifier(minid, identifier_type='hdf')
+        return self.identifiers_client.update_identifier(identifier,
                                                          metadata=metadata,
                                                          location=locations,
                                                          **kwargs)

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -261,6 +261,9 @@ class MinidClient(object):
         metadata['title'] = title
         namespace = (self.IDENTIFIERS_NAMESPACE_TEST if test is True
                      else self.IDENTIFIERS_NAMESPACE)
+        if kwargs.get('replaces'):
+            kwargs['replaces'] = self.to_identifier(kwargs['replaces'],
+                                                    identifier_type='hdl')
         return self.identifiers_client.create_identifier(
             namespace=namespace,
             visible_to=['public'],
@@ -300,6 +303,10 @@ class MinidClient(object):
         if title:
             metadata['title'] = title
         identifier = self.to_identifier(minid, identifier_type='hdl')
+        for ent in kwargs:
+            if ent in ['replaces', 'replaced_by']:
+                kwargs[ent] = self.to_identifier(kwargs[ent],
+                                                 identifier_type='hdl')
         return self.identifiers_client.update_identifier(identifier,
                                                          metadata=metadata,
                                                          location=locations,

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -197,7 +197,7 @@ class MinidClient(object):
                              test=test, metadata=metadata, replaces=replaces)
 
     def register(self, checksums, title='', locations=None, test=False,
-                 metadata=None, replaces=None):
+                 metadata=None, **kwargs):
         """Register pre-prepared data, where the checksum already exists for
         a given file."""
         if not self.is_logged_in():
@@ -222,7 +222,7 @@ class MinidClient(object):
             metadata=metadata,
             location=locations,
             checksums=supported_ck,
-            replaces=replaces,
+            **kwargs
         )
 
     def update(self, minid, title='', locations=None, metadata=None, **kwargs):
@@ -254,7 +254,7 @@ class MinidClient(object):
         locations, metadata = locations or [], metadata or {}
         if title:
             metadata['title'] = title
-        identifier = self.to_identifier(minid, identifier_type='hdf')
+        identifier = self.to_identifier(minid, identifier_type='hdl')
         return self.identifiers_client.update_identifier(identifier,
                                                          metadata=metadata,
                                                          location=locations,

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -312,9 +312,14 @@ class MinidClient(object):
         identifier = self.to_identifier(minid, identifier_type='hdl')
         for ent in kwargs:
             if ent in ['replaces', 'replaced_by']:
-                kwargs[ent] = self.to_identifier(kwargs[ent],
-                                                 identifier_type='hdl')
-        if kwargs.get('locations'):
+                # 'replaces' or 'replaced_by' MUST be either a vaild identifier
+                # or None to unset. to_identifier() will raise an exception if
+                # the identifier cannot resolve to hdl.
+                value = None if kwargs[ent] is None else self.to_identifier(
+                    kwargs[ent], identifier_type='hdl')
+                kwargs[ent] = value
+        # The 'location' field in the service is not plural
+        if 'locations' in kwargs.keys():
             kwargs['location'] = kwargs.pop('locations')
         return self.identifiers_client.update_identifier(
             identifier, **kwargs)

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -285,11 +285,15 @@ class MinidClient(object):
           ``test`` (* boolean *)
           Create the minid in a non-permanent test namespace
           ``active`` (*boolean*)
-          The state of the identifier. It is either active or inactive
+          Set the state to active or not. The state will only change if the
+          ``active`` value is passed as true or false, not including this arg
+          will leave it the same.
           ``replaces`` (*string*)
-          The id of the identifier which this identifier replaces, if any
+          The id of the identifier which this identifier replaces. None will
+          clear an existing `replaces` value.
           ``replaced_by`` (*string*)
-          The id of the identifier that replaces this identifier, if any
+          The id of the identifier that replaces this identifier. None will
+          clear an existing `replaces` value.
         """
         allowed_kwargs = {'title', 'locations', 'metadata', 'active',
                           'replaces', 'replaced_by'}

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -304,10 +304,11 @@ class MinidClient(object):
         if not self.is_logged_in():
             raise LoginRequired('The Minid Client did not have a valid '
                                 'authorizer.')
+        # Ensure metadata is set, even if it doesn't have anything in it.
+        kwargs['metadata'] = kwargs.get('metadata', {})
+        # Set title if it is given
         if title:
-            metadata = kwargs.get('metadata', {})
-            metadata['title'] = title
-            kwargs['metadata'] = metadata
+            kwargs['metadata']['title'] = title
         identifier = self.to_identifier(minid, identifier_type='hdl')
         for ent in kwargs:
             if ent in ['replaces', 'replaced_by']:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,15 @@ def mock_get_cached_created_by(monkeypatch):
 
 
 @pytest.fixture
+def mock_get_identifier(mock_identifiers_client, mock_globus_response):
+    response = mock_globus_response()
+    with open(MOCK_IDENTIFIERS) as f:
+        response.data = json.load(f)
+    mock_identifiers_client.get_identifier = Mock(return_value=response)
+    return response
+
+
+@pytest.fixture
 def mock_gcs_register(mock_identifiers_client, mock_globus_response):
     mock_globus_response = mock_globus_response()
     mock_globus_response.data = {'identifier': 'newly_minted_identifier'}

--- a/tests/files/mock_identifiers_response.json
+++ b/tests/files/mock_identifiers_response.json
@@ -1,45 +1,32 @@
-{"identifiers": [
 {
-  "admins": [],
-  "checksums": [
+  "identifiers": [
     {
-      "function": "sha256",
-      "value": "6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06"
+      "active": true,
+      "admins": [],
+      "checksums": [
+        {
+          "function": "sha256",
+          "value": "f92d11e4316ac9f282571338dba4df819203639ff5cf8d32225d857828189998"
+        }
+      ],
+      "created": "2020-04-08T14:17:53.212592",
+      "identifier": "hdl:20.500.12633/foo-identifier",
+      "landing_page": "https://identifiers.fair-research.org/hdl:20.500.12633/7TDW9m5bRh5x",
+      "location": [
+        "https://example.com/foo",
+        "https://foo.example.com"
+      ],
+      "metadata": {
+        "created_by": "Test User",
+        "length": 76,
+        "title": "newfoo.txt"
+      },
+      "replaced_by": "hdl:20.500.12633/pouLDH6pRhtw",
+      "replaces": "hdl:20.500.12633/GaVWmJdHG0Sv",
+      "updated": "2020-04-09T14:23:17.840113",
+      "visible_to": [
+        "public"
+      ]
     }
-  ],
-  "created": "2020-03-03T16:48:03.463187",
-  "identifier": "hdl:20.500.12633/foo-identifier",
-  "landing_page": "https://identifiers.fair-research.org/hdl:20.500.12633/foo.txt",
-  "location": [],
-  "metadata": {
-    "_profile": "erc",
-    "erc.what": "foo.txt"
-  },
-  "updated": "2020-03-03T16:48:03.463187",
-  "visible_to": [
-    "public"
   ]
-},
-{
-  "admins": [],
-  "checksums": [
-    {
-      "function": "sha256",
-      "value": "6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06"
-    }
-  ],
-  "created": "2020-05-03T16:48:03.463187",
-  "identifier": "hdl:20.500.12633/bar-identifier",
-  "landing_page": "https://identifiers.fair-research.org/hdl:20.500.12633/bar.txt",
-  "location": [],
-  "metadata": {
-    "_profile": "erc",
-    "erc.what": "bar.txt"
-  },
-  "updated": "2020-05-03T16:48:03.463187",
-  "visible_to": [
-    "public"
-  ]
-}
-]
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,7 +43,8 @@ def test_register(mock_identifiers_client, mocked_checksum, logged_in,
         },
         'location': [],
         'namespace': MinidClient.IDENTIFIERS_NAMESPACE,
-        'visible_to': ['public']
+        'visible_to': ['public'],
+        'replaces': None,
     }
     assert expected in mock_identifiers_client.create_identifier.call_args
 
@@ -61,10 +62,8 @@ def test_register_unsupported_checksum(mock_identifiers_client, logged_in):
         },
         'location': [],
         'namespace': MinidClient.IDENTIFIERS_NAMESPACE,
-        'visible_to': ['public']
+        'visible_to': ['public'],
     }
-    from pprint import pprint
-    pprint(mock_identifiers_client.create_identifier.call_args)
     assert expected in mock_identifiers_client.create_identifier.call_args
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -170,7 +170,8 @@ def test_update_translates_hdls(mock_identifiers_client, logged_in):
     cli.update('minid:first', replaces='minid:second', replaced_by='minid:thd')
     expected = call('hdl:20.500.12582/first',
                     replaces='hdl:20.500.12582/second',
-                    replaced_by='hdl:20.500.12582/thd')
+                    replaced_by='hdl:20.500.12582/thd',
+                    metadata={})
     assert mock_identifiers_client.update_identifier.called
     assert mock_identifiers_client.update_identifier.call_args == expected
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ import sys
 from minid.minid import MinidClient
 from minid.exc import MinidException
 
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 FILES_DIR = os.path.join(os.path.dirname(__file__), 'files')
 TEST_RFM_FILE = os.path.join(FILES_DIR, 'mock_remote_file_manifest.json')
@@ -166,11 +166,13 @@ def test_update_invalid_args(mock_identifiers_client, logged_in):
 
 def test_update_translates_hdls(mock_identifiers_client, logged_in):
     cli = MinidClient()
+
     cli.update('minid:first', replaces='minid:second', replaced_by='minid:thd')
+    expected = call('hdl:20.500.12582/first',
+                    replaces='hdl:20.500.12582/second',
+                    replaced_by='hdl:20.500.12582/thd')
     assert mock_identifiers_client.update_identifier.called
-    kwargs = dict(mock_identifiers_client.update_identifier.call_args.kwargs)
-    assert kwargs['replaces'] == 'hdl:20.500.12582/second'
-    assert kwargs['replaced_by'] == 'hdl:20.500.12582/thd'
+    assert mock_identifiers_client.update_identifier.call_args == expected
 
 
 def test_check(mock_identifiers_client, mocked_checksum):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -276,9 +276,31 @@ def test_command_print_help():
         cli.execute_command(cli, args, Mock())
 
 
+def test_pretty_print(mock_get_identifier, monkeypatch):
+    # No assertions are made here. Basically, we want to make sure pretty
+    # print does not throw errors.
+    identifier = mock_get_identifier.data['identifiers'][0]
+    cli.pretty_print_minid(minid.minid.MinidClient, identifier)
+
+
 def test_cli_print_minid(mock_get_identifier, monkeypatch):
+    """Test printing minids. Ensure that pretty print was called and the CLI
+    didn't bail out early due to another error."""
+    pretty_print_minid = Mock()
+    monkeypatch.setattr(cli, 'pretty_print_minid', pretty_print_minid)
     args = cli.cli.parse_args(['--verbose', 'check', 'minid.test:123456'])
     cli.execute_command(cli, args, Mock())
+    assert pretty_print_minid.called
+
+
+def test_cli_update_none_values(logged_in, mock_identifiers_client):
+    update = Mock()
+    mock_identifiers_client.update = update
+
+    args = cli.cli.parse_args(['update', 'minid:123', '--locations', 'none'])
+    cli.execute_command(cli, args, Mock())
+
+    assert not mock_identifiers_client.called
 
 
 def test_cli_errors(logged_out):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -87,17 +87,47 @@ LOGGED_IN_COMMANDS = [
         })
     }),
     ({
-        'command': ['update', 'foo.txt', '--title', 'My Bar'],
+        'command': ['update', 'minid:123', '--title', 'My Bar'],
         'mock': (minid.MinidClient, 'update'),
-        'expected_call_args': (['foo.txt'], {
+        'expected_call_args': (['minid:123'], {
             'title': 'My Bar'
         })
     }),
     ({
-        'command': ['update', 'foo.txt', '--locations', 'foobar.com'],
+        'command': ['update', 'minid:123', '--locations', 'foobar.com'],
         'mock': (minid.MinidClient, 'update'),
-        'expected_call_args': (['foo.txt'], {
+        'expected_call_args': (['minid:123'], {
             'locations': ['foobar.com'], 'title': None
+        })
+    }),
+    ({
+        'command': ['update', 'minid:123', '--locations', 'None'],
+        'mock': (minid.MinidClient, 'update'),
+        'expected_call_args': (['minid:123'], {
+            'locations': [], 'title': None
+        })
+    }),
+    ({
+        'command': ['update', 'minid:123', '--replaced-by', 'None'],
+        'mock': (minid.MinidClient, 'update'),
+        'expected_call_args': (['minid:123'], {
+            'replaced_by': None, 'title': None
+        })
+    }),
+    ({
+        'command': ['update', 'minid:123', '--replaces', 'None'],
+        'mock': (minid.MinidClient, 'update'),
+        'expected_call_args': (['minid:123'], {
+            'replaces': None, 'title': None
+        })
+    }),
+    ({
+        'command': ['update', 'minid:123', '--replaces', 'None',
+                    '--replaced-by', 'None', '--locations', 'None'],
+        'mock': (minid.MinidClient, 'update'),
+        'expected_call_args': (['minid:123'], {
+            'replaced_by': None, 'title': None, 'locations': [],
+            'replaces': None
         })
     }),
     ({

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -90,7 +90,6 @@ LOGGED_IN_COMMANDS = [
         'command': ['update', 'foo.txt', '--title', 'My Bar'],
         'mock': (minid.MinidClient, 'update'),
         'expected_call_args': (['foo.txt'], {
-            'locations': None,
             'title': 'My Bar'
         })
     }),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -247,6 +247,11 @@ def test_command_print_help():
         cli.execute_command(cli, args, Mock())
 
 
+def test_cli_print_minid(mock_get_identifier, monkeypatch):
+    args = cli.cli.parse_args(['--verbose', 'check', 'minid.test:123456'])
+    cli.execute_command(cli, args, Mock())
+
+
 def test_cli_errors(logged_out):
     # Raises Logout Error
     args = cli.cli.parse_args(['register', '--test', 'foo.txt'])


### PR DESCRIPTION
Support features created here: https://github.com/fair-research/fair-identifiers-client/pull/3

There are a couple oddities in this PR. A summary is: 

* Default args were being passed and overwriting values
    * See here for an explanation: https://github.com/fair-research/minid/commit/9c3409a66b78ce83646a6a3339b385f58d2305a2
*  update `active` cannot be passed directly, due to ambiguity. From the CLI, `--set-active` or `--set-inactive` will explicitly change this value. In the SDK, active isn't passed to the identifiers client if it shouldn't change. It's only explicitly passed down if given, to avoid a default automatically changing the value when it shouldn't. 

There may be better solutions here. One of the repercussions of not passing values is they cannot be nullified. For example, if someone accidentally sets 'replaced-by' for the wrong minid, there is no way to take off the erroneous 'replaced-by'. One possible fix here is setting a magic value 'None' or 'unset' to explicitly pass 'None' to clear an existing value. Example:
    * `$ minid update minid:123 --replaced-by None`