### PR TITLE
refactor: Changed the behavior of batch-register

### DIFF
--- a/minid/commands/minid_ops.py
+++ b/minid/commands/minid_ops.py
@@ -92,13 +92,17 @@ def register(filename, title, locations, replaces, test, json):
 @click.command(help='Register a batch of Minids from an RFM or file stream')
 @click.argument('filename', type=click.Path())
 @test_option
-def batch_register(filename, test):
+@click.option('--update-if-exists/--no-update-if-exists',
+              default=False, help='Update existing minids in RFM url field')
+def batch_register(filename, test, update_if_exists):
     """Register a batch of Minids from an RFM or file stream
 
     Batch Register can either be passed a file to a Remote File Manifest JSON
     file, or streamed where each entry in the stream is an RFM formatted dict.
     """
-    click.echo(json.dumps(commands.get_client().batch_register(filename, test), indent=2))
+    batch_register = commands.get_client().batch_register(filename, test,
+                                                          update_if_exists=update_if_exists)
+    click.echo(json.dumps(batch_register, indent=2))
 
 
 @click.command(help='Update an existing Minid')

--- a/minid/minid.py
+++ b/minid/minid.py
@@ -398,6 +398,9 @@ class MinidClient(object):
             python hashlib should work too.
           ``test`` (*boolean*)
             Register using a minid test namespace
+          ``update_if_exists`` (*bool*) Default False. Attempt to keep an
+            existing minid if one exists and the checksum matches. Otherwise
+            re-register and replace the existing minid.
         ** Returns **
             A dict with 'url' replaced with the registered identifier
         ** Example **
@@ -459,8 +462,10 @@ class MinidClient(object):
     def batch_register(self, manifest_filename, test, update_if_exists=False):
         """
         Register All entries within a remote file manifest, and replace the
-        'url' on each record with an identifier. A minid is always registered
-        unless `update_if_exists` is True.
+        'url' on each record with an identifier. Existing identifiers will
+        be re-registered and replaced with a new identifier. update_if_exists
+        will attempt to keep the same identifier if the checksum matches the
+        original, in which it will update the old minids information.
 
         The manifest must conform to the bdbag spec laid out here:
         https://github.com/fair-research/bdbag/blob/master/doc/config.md#remote-file-manifest  # noqa
@@ -472,6 +477,9 @@ class MinidClient(object):
           ``test`` (*bool*) Register in the temporary test namespace, or the
             permanent production namespace. Records are not re-registered if
             one already exists.
+          ``update_if_exists`` (*bool*) Default False. Attempt to keep an
+            existing minid if one exists and the checksum matches. Otherwise
+            re-register and replace the existing minid.
         ** Returns **
           A list of records with 'url' field replaced with the identifier. See
           get_or_register_rfm() above for more details.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import minid
 
 BASE_DIR = os.path.join(os.path.dirname(__file__), 'files')
 TEST_RFM = os.path.join(BASE_DIR, 'mock_remote_file_manifest.json')
+TEST_RFM_IDENTIFIERS = os.path.join(BASE_DIR, 'mock_remote_file_manifest_identifiers.json')
 MOCK_IDENTIFIERS = os.path.join(BASE_DIR, 'mock_identifiers_response.json')
 MOCK_IDENTIFIERS_MULT = os.path.join(BASE_DIR, 'mock_identifiers_response_mult.json')
 
@@ -104,6 +105,15 @@ def mock_gcs_register(mock_identifiers_client, mock_globus_response):
 
 
 @pytest.fixture
+def mock_gcs_update(mock_identifiers_client, mock_globus_response):
+    mock_globus_response = mock_globus_response()
+    mock_globus_response.data = {'identifier': 'updated_identifier'}
+    mock_identifiers_client.update_identifier.return_value = \
+        mock_globus_response
+    return mock_identifiers_client.update_identifier
+
+
+@pytest.fixture
 def mock_gcs_get_by_checksum(mock_identifiers_client, mock_globus_response):
     mock_globus_response = mock_globus_response()
     with open(MOCK_IDENTIFIERS) as f:
@@ -123,6 +133,11 @@ def mocked_checksum(monkeypatch):
 @pytest.fixture
 def mock_rfm_filename():
     return TEST_RFM
+
+
+@pytest.fixture
+def mock_rfm_identifiers_filename():
+    return TEST_RFM_IDENTIFIERS
 
 
 @pytest.fixture

--- a/tests/files/mock_remote_file_manifest_identifiers.json
+++ b/tests/files/mock_remote_file_manifest_identifiers.json
@@ -1,0 +1,12 @@
+[
+    {
+        "url": "hdl:20.500.12633/test1",
+        "sha256": "6e3fbc3cc8c58edd0d99cd4925d168a48cdbd7ffbfa1a72fb0371526fb201c06",
+        "filename": "foo.txt"
+    },
+    {
+        "url": "hdl:20.500.12633/test2",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "filename": "bar.txt"
+    }
+]


### PR DESCRIPTION
Batch register now always registers a new Minid by default. A new
option, 'update_if_exists', is available to use an existing Minid
supplied in the `url` field if it is present, and update it instead.

This change resulted from discussion reviewing the bug report
here #75, and how this could result in undesirable behavior if
the checksums for given files were 'common' (for instance, if a
file was empty or contained content such as '1', this could return
another persons Minid). 