### PR TITLE
docs: Update readme to remove --pre

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Usage
 -----
 Minid 2.0.0 requires python 3.6 or higher::
 
-  $ pip install --pre minid
+  $ pip install minid
 
 Minting identifiers is simple and easy::
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Minimal Viable Identifier Client
 A minid (Minimal Viable Identifier) is an identifier that is sufficiently simple to make creation and use trivial, while still having enough substance to make data easily findable, accessible, interoperable, and reusable (FAIR). 
 
 
-See the `Read The Docs <https://minid.readthedocs.io/en/develop>`_ page for more info.
+See the `Read The Docs <https://minid.readthedocs.io/en/stable>`_ page for more info.
 
 Usage
 -----

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,12 +22,8 @@ Installation
 
 Minid Client 2.0.0 is avaialble on PyPI. You can install it with the following command::
 
-  $ pip install --pre minid
+  $ pip install minid
 
-
-You can also install the `legacy Minid 1.3.0 version <https://github.com/fair-research/minid/tree/1.3.0>`_ with::
-
-  $ pip install minid==1.3.0
 
 Alternatively, you can download the source code and install using setup tools::
 


### PR DESCRIPTION
--pre were needed when minid 2.0.0 was in beta. No longer! Minid 2.0.0
is now stable on pypi